### PR TITLE
Update Licenses.json

### DIFF
--- a/jsonld/Licenses.json
+++ b/jsonld/Licenses.json
@@ -60,6 +60,12 @@
             "licenseUrl": "https://spdx.org/licenses/MIT"
         },
         {
+            "@id": "https://Heliophysics-Software-Search-Interface.readthedocs.io/en/latest.html/Licenses#Restricted",
+            "@type": "Concept",
+            "prefLabel": "Restricted",
+            "inScheme": "https://Heliophysics-Software-Search-Interface.readthedocs.io/en/latest.html/Licenses"
+        }        
+        {
             "@id": "https://Heliophysics-Software-Search-Interface.readthedocs.io/en/latest.html/Licenses#Other",
             "@type": "Concept",
             "prefLabel": "Other",


### PR DESCRIPTION
We need a "Restricted" option for software licenses to accommodate software that is restricted. I cannot add a large portion of modeling software without this.  @jibarnum This enables us to list software where access must be requested, as discussed with NASA Heliophysics archive leadership.